### PR TITLE
NXP-22403: initialize current principal user workspace

### DIFF
--- a/nuxeo-drive-operations/src/test/java/org/nuxeo/drive/hierarchy/userworkspace/TestUserWorkspaceHierarchy.java
+++ b/nuxeo-drive-operations/src/test/java/org/nuxeo/drive/hierarchy/userworkspace/TestUserWorkspaceHierarchy.java
@@ -163,6 +163,9 @@ public class TestUserWorkspaceHierarchy {
 
         storageConfiguration = coreFeature.getStorageConfiguration();
 
+        // Create user workspace for Administrator
+        userWorkspaceService.getCurrentUserPersonalWorkspace(session, null);
+
         // Create test user
         createUser("user1", "user1");
 


### PR DESCRIPTION
To prevent Nuxeo Drive listener(s) to create the Administrator user workspace, which leads to failures when commiting the current transaction with the `getOrCreate` method, we should initialize this workspace when setting up the test.
 