### PR TITLE
NXP-23307: Fix LoginConfig duplicate by removing JtajcaManagementFeature from NuxeoDriveFeature

### DIFF
--- a/nuxeo-drive-core/src/test/java/org/nuxeo/drive/test/NuxeoDriveFeature.java
+++ b/nuxeo-drive-core/src/test/java/org/nuxeo/drive/test/NuxeoDriveFeature.java
@@ -16,14 +16,13 @@
  */
 package org.nuxeo.drive.test;
 
-import org.nuxeo.ecm.core.management.jtajca.JtajcaManagementFeature;
 import org.nuxeo.ecm.platform.test.PlatformFeature;
 import org.nuxeo.runtime.test.runner.Deploy;
 import org.nuxeo.runtime.test.runner.Features;
 import org.nuxeo.runtime.test.runner.LocalDeploy;
 import org.nuxeo.runtime.test.runner.SimpleFeature;
 
-@Features({ JtajcaManagementFeature.class, PlatformFeature.class, SQLAuditFeature.class })
+@Features({ PlatformFeature.class, SQLAuditFeature.class })
 @Deploy({ "org.nuxeo.drive.core", "org.nuxeo.ecm.core.io", "org.nuxeo.runtime.reload", "org.nuxeo.ecm.core.cache",
         "org.nuxeo.ecm.platform.types.core", "org.nuxeo.ecm.platform.userworkspace.types",
         "org.nuxeo.ecm.platform.userworkspace.core", "org.nuxeo.ecm.platform.collections.core",


### PR DESCRIPTION
The problem seemed to be that:
- `JtajcaManagementFeature` deploys ["org.nuxeo.ecm.core.management.jtajca:login-config.xml"](https://github.com/nuxeo/nuxeo/blob/master/nuxeo-core/nuxeo-core-management-jtajca/src/test/resources/login-config.xml)
- `NuxeoDriveAutomationFeature` uses `EmbeddedAutomationServerFeature` thus `WebEngineFeature` that deploys ["org.nuxeo.ecm.webengine.test:login-config.xml"](https://github.com/nuxeo/nuxeo/blob/master/nuxeo-features/nuxeo-features-test/src/main/resources/login-config.xml)

=> 2 `"nuxeo-system-login"` domain contributions leading to an authentication issue.

Originally, `JtajcaManagementFeature` was added to `NuxeoDriveFeature` by [NXP-20338](https://jira.nuxeo.com/browse/NXP-20338) in https://github.com/nuxeo/nuxeo-drive-server/commit/198145467902c931515031fc13944cd188c59aad#diff-53c643ac401484c6f199538d79285762R26, probably for debug purpose.