### PR TITLE
NXP-24596: use trash service instead of followTransition('delete')

### DIFF
--- a/nuxeo-drive-core/src/main/java/org/nuxeo/drive/listener/NuxeoDriveCacheInvalidationListener.java
+++ b/nuxeo-drive-core/src/main/java/org/nuxeo/drive/listener/NuxeoDriveCacheInvalidationListener.java
@@ -18,6 +18,9 @@
  */
 package org.nuxeo.drive.listener;
 
+import static org.nuxeo.ecm.core.trash.TrashService.DOCUMENT_TRASHED;
+import static org.nuxeo.ecm.core.trash.TrashService.DOCUMENT_UNTRASHED;
+
 import org.nuxeo.drive.service.NuxeoDriveManager;
 import org.nuxeo.ecm.collections.api.CollectionConstants;
 import org.nuxeo.ecm.core.api.IdRef;
@@ -42,8 +45,10 @@ public class NuxeoDriveCacheInvalidationListener implements EventListener {
             return;
         }
         String transition = (String) docCtx.getProperty(LifeCycleConstants.TRANSTION_EVENT_OPTION_TRANSITION);
-        if (transition != null
-                && !(LifeCycleConstants.DELETE_TRANSITION.equals(transition) || LifeCycleConstants.UNDELETE_TRANSITION.equals(transition))) {
+        String eventName = event.getName();
+        if (!DOCUMENT_TRASHED.equals(eventName) && !DOCUMENT_UNTRASHED.equals(eventName) && transition != null
+                && !(LifeCycleConstants.DELETE_TRANSITION.equals(transition)
+                        || LifeCycleConstants.UNDELETE_TRANSITION.equals(transition))) {
             // not interested in lifecycle transitions that are not related to
             // document deletion
             return;

--- a/nuxeo-drive-core/src/main/java/org/nuxeo/drive/listener/NuxeoDriveFileSystemDeletionListener.java
+++ b/nuxeo-drive-core/src/main/java/org/nuxeo/drive/listener/NuxeoDriveFileSystemDeletionListener.java
@@ -18,6 +18,9 @@
  */
 package org.nuxeo.drive.listener;
 
+import static org.nuxeo.ecm.core.trash.TrashService.DOCUMENT_TRASHED;
+import static org.nuxeo.ecm.core.trash.TrashService.DOCUMENT_UNTRASHED;
+
 import java.security.Principal;
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -100,8 +103,11 @@ public class NuxeoDriveFileSystemDeletionListener implements EventListener {
                 return;
             }
         }
-        if (LifeCycleConstants.TRANSITION_EVENT.equals(event.getName()) && !handleLifeCycleTransition(ctx)) {
-            return;
+        if (!DOCUMENT_TRASHED.equals(event.getName())) {
+            // Fallback on the transition event check
+            if (LifeCycleConstants.TRANSITION_EVENT.equals(event.getName()) && !handleLifeCycleTransition(ctx)) {
+                return;
+            }
         }
         if (DocumentEventTypes.ABOUT_TO_REMOVE.equals(event.getName()) && !handleAboutToRemove(doc)) {
             return;

--- a/nuxeo-drive-core/src/test/java/org/nuxeo/drive/fixtures/DefaultFileSystemItemFactoryFixture.java
+++ b/nuxeo-drive-core/src/test/java/org/nuxeo/drive/fixtures/DefaultFileSystemItemFactoryFixture.java
@@ -70,6 +70,7 @@ import org.nuxeo.ecm.core.api.security.ACL;
 import org.nuxeo.ecm.core.api.security.ACP;
 import org.nuxeo.ecm.core.api.security.SecurityConstants;
 import org.nuxeo.ecm.core.test.CoreFeature;
+import org.nuxeo.ecm.core.trash.TrashService;
 import org.nuxeo.ecm.core.versioning.VersioningService;
 import org.nuxeo.runtime.api.Framework;
 import org.nuxeo.runtime.reload.ReloadService;
@@ -114,6 +115,9 @@ public class DefaultFileSystemItemFactoryFixture {
 
     @Inject
     protected CollectionManager collectionManager;
+
+    @Inject
+    protected TrashService trashService;
 
     protected Principal principal;
 
@@ -248,7 +252,7 @@ public class DefaultFileSystemItemFactoryFixture {
         assertNull(fsItem);
 
         // Deleted file => not adaptable as a FileSystemItem
-        custom.followTransition("delete");
+        trashService.trashDocument(custom);
         assertFalse(defaultFileSystemItemFactory.isFileSystemItem(custom));
         assertNull(defaultFileSystemItemFactory.getFileSystemItem(custom));
 
@@ -474,7 +478,7 @@ public class DefaultFileSystemItemFactoryFixture {
         assertFalse(defaultFileSystemItemFactory.exists(DEFAULT_FILE_SYSTEM_ITEM_ID_PREFIX + notAFileSystemItem.getId(),
                 principal));
         // Deleted
-        file.followTransition("delete");
+        trashService.trashDocument(file);
         assertFalse(defaultFileSystemItemFactory.exists(DEFAULT_FILE_SYSTEM_ITEM_ID_PREFIX + file.getId(), principal));
     }
 
@@ -521,7 +525,7 @@ public class DefaultFileSystemItemFactoryFixture {
                 DEFAULT_FILE_SYSTEM_ITEM_ID_PREFIX + notAFileSystemItem.getId(), principal);
         assertNull(fsItem);
         // Deleted
-        custom.followTransition("delete");
+        trashService.trashDocument(custom);
         fsItem = defaultFileSystemItemFactory.getFileSystemItemById(DEFAULT_FILE_SYSTEM_ITEM_ID_PREFIX + custom.getId(),
                 principal);
         assertNull(fsItem);

--- a/nuxeo-drive-core/src/test/java/org/nuxeo/drive/service/TestNuxeoDriveManager.java
+++ b/nuxeo-drive-core/src/test/java/org/nuxeo/drive/service/TestNuxeoDriveManager.java
@@ -60,6 +60,7 @@ import org.nuxeo.ecm.core.test.CoreFeature;
 import org.nuxeo.ecm.core.test.DefaultRepositoryInit;
 import org.nuxeo.ecm.core.test.TransactionalFeature;
 import org.nuxeo.ecm.core.test.annotations.RepositoryConfig;
+import org.nuxeo.ecm.core.trash.TrashService;
 import org.nuxeo.ecm.directory.Session;
 import org.nuxeo.ecm.directory.api.DirectoryService;
 import org.nuxeo.ecm.platform.usermanager.UserManager;
@@ -107,6 +108,9 @@ public class TestNuxeoDriveManager {
 
     @Inject
     TransactionalFeature txFeature;
+
+    @Inject
+    protected TrashService trashService;
 
     protected CoreSession user1Session;
 
@@ -388,15 +392,14 @@ public class TestNuxeoDriveManager {
 
         // Delete sync root => nuxeoDriveCacheInvalidationListener should
         // invalidate the cache
-        session.followTransition(workspace_2.getRef(), "delete");
-        session.save();
+        trashService.trashDocument(workspace_2);
+        workspace_2 = session.getDocument(workspace_2.getRef());
         expectedSyncRootPaths.remove("/default-domain/workspaces/workspace-2");
         checkRoots(user1Principal, 1, expectedSyncRootPaths);
 
         // Undelete sync root => nuxeoDriveCacheInvalidationListener should
         // invalidate the cache
-        session.followTransition(workspace_2.getRef(), "undelete");
-        session.save();
+        trashService.untrashDocument(workspace_2);
         expectedSyncRootPaths.add("/default-domain/workspaces/workspace-2");
         checkRoots(user1Principal, 2, expectedSyncRootPaths);
 

--- a/nuxeo-drive-core/src/test/java/org/nuxeo/drive/service/adapter/TestFileSystemItemManagerService.java
+++ b/nuxeo-drive-core/src/test/java/org/nuxeo/drive/service/adapter/TestFileSystemItemManagerService.java
@@ -58,7 +58,9 @@ import org.nuxeo.ecm.core.api.security.ACL;
 import org.nuxeo.ecm.core.api.security.ACP;
 import org.nuxeo.ecm.core.api.security.SecurityConstants;
 import org.nuxeo.ecm.core.test.CoreFeature;
+import org.nuxeo.ecm.core.trash.TrashService;
 import org.nuxeo.ecm.platform.usermanager.NuxeoPrincipalImpl;
+import org.nuxeo.runtime.api.Framework;
 import org.nuxeo.runtime.test.runner.Features;
 import org.nuxeo.runtime.test.runner.FeaturesRunner;
 import org.nuxeo.runtime.transaction.TransactionHelper;
@@ -198,7 +200,7 @@ public class TestFileSystemItemManagerService {
         assertFalse(fileSystemItemManagerService.exists(DEFAULT_FILE_SYSTEM_ITEM_ID_PREFIX + notAFileSystemItem.getId(),
                 principal));
         // Deleted
-        custom.followTransition("delete");
+        Framework.getService(TrashService.class).trashDocument(custom);
         assertFalse(
                 fileSystemItemManagerService.exists(DEFAULT_FILE_SYSTEM_ITEM_ID_PREFIX + custom.getId(), principal));
 

--- a/nuxeo-drive-operations/src/test/java/org/nuxeo/drive/operations/TestFileSystemItemOperations.java
+++ b/nuxeo-drive-operations/src/test/java/org/nuxeo/drive/operations/TestFileSystemItemOperations.java
@@ -64,6 +64,7 @@ import org.nuxeo.ecm.core.api.security.ACL;
 import org.nuxeo.ecm.core.api.security.ACP;
 import org.nuxeo.ecm.core.api.security.SecurityConstants;
 import org.nuxeo.ecm.core.test.CoreFeature;
+import org.nuxeo.ecm.core.trash.TrashService;
 import org.nuxeo.ecm.directory.api.DirectoryService;
 import org.nuxeo.ecm.platform.usermanager.UserManager;
 import org.nuxeo.runtime.api.Framework;
@@ -101,6 +102,9 @@ public class TestFileSystemItemOperations {
 
     @Inject
     protected FileSystemItemAdapterService fileSystemItemAdapterService;
+
+    @Inject
+    protected TrashService trashService;
 
     @Inject
     protected NuxeoDriveManager nuxeoDriveManager;
@@ -265,7 +269,7 @@ public class TestFileSystemItemOperations {
         assertEquals("true", fileSystemItemExists);
 
         // Deleted file system item
-        file1.followTransition("delete");
+        trashService.trashDocument(file1);
         // Need to flush VCS cache to be aware of changes in the session used by the file system item
         TransactionHelper.commitOrRollbackTransaction();
         TransactionHelper.startTransaction();
@@ -346,7 +350,7 @@ public class TestFileSystemItemOperations {
                 fileItem.getDigest());
 
         // Get deleted file
-        file1.followTransition("delete");
+        trashService.trashDocument(file1);
         // Need to flush VCS cache to be aware of changes in the session used by the file system item
         TransactionHelper.commitOrRollbackTransaction();
         TransactionHelper.startTransaction();


### PR DESCRIPTION
T&P : https://qa.nuxeo.org/jenkins/view/TestAndPush/job/TestAndPush/job/ondemand-testandpush-fdavid-master/382/